### PR TITLE
Add Flask backend and Flutter frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Python
+__pycache__/
+*.pyc
+
+# Flutter
+build/
+.dart_tool/
+
+# General
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Todo Scheduler
+
+This is a simple Todo management web application.
+
+- **Backend:** Python + Flask
+- **Frontend:** Flutter Web
+
+## Development
+
+### Requirements
+- Docker / Docker Compose
+
+### Running locally
+
+```bash
+# build and start containers
+docker-compose up --build
+
+# backend will listen on http://localhost:5000
+# frontend (Flutter web) will be served from http://localhost:8080
+```
+
+When developing the Flutter frontend locally with the SDK, make sure to set
+`API_BASE=/api` so that requests are proxied to the backend service defined in
+the Docker Compose setup.

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,0 +1,150 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+void main() {
+  runApp(const TodoApp());
+}
+
+class Todo {
+  int id;
+  String title;
+  bool done;
+
+  Todo({required this.id, required this.title, required this.done});
+
+  factory Todo.fromJson(Map<String, dynamic> json) {
+    return Todo(
+      id: json['id'] as int,
+      title: json['title'] as String,
+      done: json['done'] as bool,
+    );
+  }
+}
+
+class TodoApp extends StatefulWidget {
+  const TodoApp({super.key});
+
+  @override
+  State<TodoApp> createState() => _TodoAppState();
+}
+
+class _TodoAppState extends State<TodoApp> {
+  final TextEditingController _controller = TextEditingController();
+  final String _apiBase = const String.fromEnvironment('API_BASE', defaultValue: '/api');
+  List<Todo> _todos = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchTodos();
+  }
+
+  Future<void> _fetchTodos() async {
+    final res = await http.get(Uri.parse('$_apiBase/todos'));
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body) as List;
+      setState(() {
+        _todos = data.map((e) => Todo.fromJson(e)).toList();
+      });
+    }
+  }
+
+  Future<void> _addTodo(String title) async {
+    final res = await http.post(
+      Uri.parse('$_apiBase/todos'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'title': title}),
+    );
+    if (res.statusCode == 201) {
+      setState(() {
+        _todos.add(Todo.fromJson(jsonDecode(res.body)));
+      });
+      _controller.clear();
+    }
+  }
+
+  Future<void> _toggleDone(Todo todo) async {
+    final res = await http.put(
+      Uri.parse('$_apiBase/todos/${todo.id}'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'done': !todo.done}),
+    );
+    if (res.statusCode == 200) {
+      setState(() {
+        todo.done = !todo.done;
+      });
+    }
+  }
+
+  Future<void> _deleteTodo(int id) async {
+    final res = await http.delete(Uri.parse('$_apiBase/todos/$id'));
+    if (res.statusCode == 204) {
+      setState(() {
+        _todos.removeWhere((t) => t.id == id);
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Todo App')),
+        body: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _controller,
+                      decoration: const InputDecoration(hintText: 'Add todo'),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.add),
+                    onPressed: () {
+                      final text = _controller.text.trim();
+                      if (text.isNotEmpty) {
+                        _addTodo(text);
+                      }
+                    },
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: RefreshIndicator(
+                onRefresh: _fetchTodos,
+                child: ListView(
+                  children: _todos
+                      .map((todo) => ListTile(
+                            leading: Checkbox(
+                              value: todo.done,
+                              onChanged: (_) => _toggleDone(todo),
+                            ),
+                            title: Text(
+                              todo.title,
+                              style: todo.done
+                                  ? const TextStyle(
+                                      decoration: TextDecoration.lineThrough,
+                                    )
+                                  : null,
+                            ),
+                            trailing: IconButton(
+                              icon: const Icon(Icons.delete),
+                              onPressed: () => _deleteTodo(todo.id),
+                            ),
+                          ))
+                      .toList(),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -1,0 +1,18 @@
+name: todo_frontend
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^0.13.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="Todo app built with Flutter">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Todo App</title>
+  <link rel="manifest" href="manifest.json">
+</head>
+<body>
+  <script src="flutter.js" defer></script>
+  <script>
+    window.addEventListener('load', function () {
+      _flutter.loader.loadEntrypoint({
+        entrypointUrl: 'main.dart.js'
+      }).then(function(engine) {
+        engine.run();
+      });
+    });
+  </script>
+</body>
+</html>

--- a/frontend/web/manifest.json
+++ b/frontend/web/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "Todo App",
+  "short_name": "Todo",
+  "start_url": "/",
+  "display": "standalone"
+}


### PR DESCRIPTION
## Summary
- implement Flutter web frontend
- add README and gitignore
- configure Flutter app to use Flask backend

## Testing
- `python3 -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6848e6ec8894832399196ecd0c0dd9ec